### PR TITLE
Subgraph should output a graph of type DG

### DIFF
--- a/lib/dg.ex
+++ b/lib/dg.ex
@@ -205,12 +205,10 @@ defmodule DG do
     :digraph_utils.strong_components(dg)
   end
 
-  def subgraph(%__MODULE__{dg: dg}, vertices) do
-    :digraph_utils.subgraph(dg, vertices)
-  end
-
-  def subgraph(%__MODULE__{dg: dg}, vertices, options) do
-    :digraph_utils.subgraph(dg, vertices, options)
+  def subgraph(%__MODULE__{dg: dg}, vertices, options \\ []) do
+    {digraph_opts, opts} = Keyword.pop(options, :digraph_opts, [])
+    subgraph = :digraph_utils.subgraph(dg, vertices, digraph_opts)
+    %__MODULE__{dg: subgraph, opts: opts}
   end
 
   def topsort(%__MODULE__{dg: dg}) do

--- a/test/dg_test.exs
+++ b/test/dg_test.exs
@@ -112,6 +112,27 @@ defmodule DG.Test do
     end
   end
 
+  describe "subgraph" do
+    test "returns a DG" do
+      dg = DG.new(test: true)
+      ~w(a b c d e) |> Enum.map(&{:vertex, &1}) |> Enum.into(dg)
+
+      assert %DG{} = DG.subgraph(dg, ~w(a b c))
+    end
+
+    test "handles digraph options" do
+      dg = DG.new(test: true)
+      ~w(a b c) |> Enum.map(&{:vertex, &1}) |> Enum.into(dg)
+
+      label = "a -> b"
+      Enum.into([{:edge, "a", "b", label}], dg)
+
+      subgraph = DG.subgraph(dg, ~w(a b), digraph_opts: [keep_labels: true])
+
+      assert {_, "a", "b", ^label} = DG.edge(subgraph, List.first(DG.edges(dg, "a")))
+    end
+  end
+
   describe "sigil" do
     import DG.Sigil
 

--- a/test/dg_test.exs
+++ b/test/dg_test.exs
@@ -136,7 +136,7 @@ defmodule DG.Test do
   describe "sigil" do
     import DG.Sigil
 
-    test "ingetration" do
+    test "integration" do
       dg = ~g"""
       graph LR
       a[aaaaa]


### PR DESCRIPTION
Updates `subgraph` to handle digraph_opts as `new`, and transforms `:digraph`'s output into type DG

Closes #24 