### PR TITLE
Support non string labels

### DIFF
--- a/lib/inspect.ex
+++ b/lib/inspect.ex
@@ -21,7 +21,7 @@ defimpl Inspect, for: DG do
                 [inspect_node(dg, v), "-->", inspect_node(dg, n)]
 
               {_e, ^v, n, label} ->
-                [inspect_node(dg, v), "--", label, "-->", inspect_node(dg, n)]
+                [inspect_node(dg, v), "--", inspect_term(label), "-->", inspect_node(dg, n)]
             end)
             |> Enum.intersperse([line()])
         end
@@ -49,8 +49,11 @@ defimpl Inspect, for: DG do
   defp label(dg, v, prefix) do
     case :digraph.vertex(dg, v) do
       {^v, []} -> [prefix]
-      {^v, l} -> [prefix, "[", l, "]"]
+      {^v, l} -> [prefix, "[", inspect_term(l), "]"]
     end
     |> concat
   end
+
+  defp inspect_term(term) when is_binary(term), do: term
+  defp inspect_term(term), do: inspect(term)
 end

--- a/test/dg_test.exs
+++ b/test/dg_test.exs
@@ -74,6 +74,18 @@ defmodule DG.Test do
                    1--one to two-->2[two]
                """)
     end
+
+    test "fancy labels", %{dg: dg} do
+      DG.add_vertex(dg, 1)
+      DG.add_vertex(dg, 2, :c.pid(0, 42, 42))
+      DG.add_edge(dg, 1, 2, :"one to two")
+
+      assert inspect(dg) ==
+               String.trim("""
+               graph LR
+                   1--:\"one to two\"-->2[#PID<0.42.42>]
+               """)
+    end
   end
 
   describe "collectable" do


### PR DESCRIPTION
Hi 👋 

Non-string labels are passed to inspect result as-is which doesn't work for e.g. atoms:

```elixir
iex(2)> DG.new() |> tap(& DG.add_vertex(&1, 1, :foo))
#Inspect.Error<
  got FunctionClauseError with message:

      """
      no function clause matching in Inspect.Algebra.concat/2
      """

  while inspecting:

      %{
        opts: [],
        __struct__: DG,
        dg: {:digraph, #Reference<0.220188636.626130951.253424>,
         #Reference<0.220188636.626130951.253425>,
         #Reference<0.220188636.626130951.253426>, true}
      }

  Stacktrace:

    (elixir 1.16.3) lib/inspect/algebra.ex:587: Inspect.Algebra.concat(:foo, "]")
    (elixir 1.16.3) lib/inspect/algebra.ex:946: Inspect.Algebra.fold_doc/2
    (dg 0.4.0) lib/inspect.ex:14: anonymous fn/2 in Inspect.DG.inspect/2
    (elixir 1.16.3) lib/enum.ex:1700: Enum."-map/2-lists^map/1-1-"/2
    (dg 0.4.0) lib/inspect.ex:11: Inspect.DG.inspect/2
    (elixir 1.16.3) lib/inspect/algebra.ex:347: Inspect.Algebra.to_doc/2
    (elixir 1.16.3) lib/kernel.ex:2352: Kernel.inspect/2
    (iex 1.16.3) lib/iex/evaluator.ex:376: IEx.Evaluator.io_inspect/1

>
```